### PR TITLE
Add MuUser domain model class

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,6 @@
 import json
 
 from . import db
-from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
 
@@ -20,7 +19,6 @@ class MuUser(db.Model):
     )
     name = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(64), unique=True, nullable=False)
-    password_hash = db.Column(db.String(128), nullable=False)
     role = db.Column(db.String(32), unique=True, nullable=False)
     # Relationships
     notes = db.relationship("Note", backref="user", lazy=True)
@@ -32,7 +30,6 @@ class MuUser(db.Model):
         return {
             "id": self.id,
             "name": self.name,
-            "password_hash": self.password_hash,
             "email": self.email,
             "role": self.role,
         }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,7 +27,7 @@ class MuUser(db.Model):
             "name": self.name,
             "password_hash": self.password_hash,
             "email": self.email,
-            "role": self.role,
+            "role": self.role
         }
     @staticmethod
     def serialize_list(users):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,28 +1,13 @@
 import json
 
-from . import db, http_auth
-from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
-from itsdangerous import BadSignature, SignatureExpired
+from . import db
 from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
 # create model classes here
 
-
-#Authorization for User
-@http_auth.verify_token
-def verify_auth_token(token):
-    s = Serializer(current_app.config["SECRET_KEY"])
-    try:
-        data = s.loads(token)
-    except SignatureExpired:
-        return False  # valid token, but expired
-    except BadSignature:
-        return False  # invalid token
-    user = MuUser.query.get(data["token"])
-    return user
-#MuUser Domain Model Class
-class MuUser(db.Model)    
+# MuUser Domain Model Class
+class MuUser(db.Model):   
     #Initializing Table
     __tablename__='users'
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True, nullable=False)
@@ -31,27 +16,8 @@ class MuUser(db.Model)
     password_hash = db.Column(db.String(128), nullable=False)
     role = db.Column(db.String(32), unique=True, nullable=False)
     #Relationships
-    notes = db.relationship("Note", backref="user")
-    donations = db.relationship("Donation", backref="user")
-    #Password Properties
-    @property
-    def password(self):
-        raise AttributeError("password is not a readable attribute")
-    @password.setter
-    def password(self, password):
-        self.password_hash = generate_password_hash(password)
-    def verify_password(self, password):
-        return check_password_hash(self.password_hash, password)
-    def change_password(self, old_password, new_password):
-        if not self.verify_password(old_password):
-            return False
-        self.password = new_password
-        db.session.add(self)
-        db.session.commit()
-        return True
-    def generate_auth_token(self, expiration=86400):
-        s = Serializer(current_app.config["SECRET_KEY"], expiration)
-        return s.dumps({"token": self.id})
+    notes = db.relationship("Note", backref="user", lazy=True)
+    donations = db.relationship("Donation", backref="user", lazy=True)
     #Serialize class
     @property
     def serialize(self):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,21 +4,28 @@ from . import db
 from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
+
 # create model classes here
 
 # MuUser Domain Model Class
-class MuUser(db.Model):   
-    #Initializing Table
-    __tablename__='users'
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True, nullable=False)
+class MuUser(db.Model):
+    # Initializing Table
+    __tablename__ = "users"
+    id = db.Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        unique=True,
+        nullable=False,
+    )
     name = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(64), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
     role = db.Column(db.String(32), unique=True, nullable=False)
-    #Relationships
+    # Relationships
     notes = db.relationship("Note", backref="user", lazy=True)
     donations = db.relationship("Donation", backref="user", lazy=True)
-    #Serialize class
+    # Serialize class
     @property
     def serialize(self):
         """Return object data in serializeable format"""
@@ -27,13 +34,15 @@ class MuUser(db.Model):
             "name": self.name,
             "password_hash": self.password_hash,
             "email": self.email,
-            "role": self.role
+            "role": self.role,
         }
+
     @staticmethod
     def serialize_list(users):
         json_users = []
         for user in users:
             json_users.append(user.serialize)
         return json_users
+
     def __repr__(self):
         return "<User %r>" % self.email

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,73 @@
 import json
 
-from . import db
+from . import db, http_auth
+from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
+from itsdangerous import BadSignature, SignatureExpired
 from werkzeug.security import generate_password_hash, check_password_hash
-
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
 # create model classes here
+
+
+#Authorization for User
+@http_auth.verify_token
+def verify_auth_token(token):
+    s = Serializer(current_app.config["SECRET_KEY"])
+    try:
+        data = s.loads(token)
+    except SignatureExpired:
+        return False  # valid token, but expired
+    except BadSignature:
+        return False  # invalid token
+    user = User.query.get(data["token"])
+    return user
+#MuUser Domain Model Class
+class User(db.Model)    
+    #Initializing Table
+    __tablename__='users'
+    user_id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True, nullable=False)
+    name = db.Column(db.String(64), nullable=False)
+    email = db.Column(db.String(64), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(32), unique=True, nullable=False)
+    #Relationships
+    notes = db.relationship("Note", backref="user")
+    donations = db.relationship("Donation", backref="user")
+    #Password Properties
+    @property
+    def password(self):
+        raise AttributeError("password is not a readable attribute")
+    @password.setter
+    def password(self, password):
+        self.password_hash = generate_password_hash(password)
+    def verify_password(self, password):
+        return check_password_hash(self.password_hash, password)
+    def change_password(self, old_password, new_password):
+        if not self.verify_password(old_password):
+            return False
+        self.password = new_password
+        db.session.add(self)
+        db.session.commit()
+        return True
+    def generate_auth_token(self, expiration=86400):
+        s = Serializer(current_app.config["SECRET_KEY"], expiration)
+        return s.dumps({"token": self.user_id})
+    #Serialize class
+    @property
+    def serialize(self):
+        """Return object data in serializeable format"""
+        return {
+            "user_id": self.user_id,
+            "name": self.name,
+            "password_hash": self.password_hash,
+            "email": self.email,
+            "role": self.role,
+        }
+    @staticmethod
+    def serialize_list(users):
+        json_users = []
+        for user in users:
+            json_users.append(user.serialize)
+        return json_users
+    def __repr__(self):
+        return "<User %r>" % self.email

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -19,13 +19,13 @@ def verify_auth_token(token):
         return False  # valid token, but expired
     except BadSignature:
         return False  # invalid token
-    user = User.query.get(data["token"])
+    user = MuUser.query.get(data["token"])
     return user
 #MuUser Domain Model Class
-class User(db.Model)    
+class MuUser(db.Model)    
     #Initializing Table
     __tablename__='users'
-    user_id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True, nullable=False)
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True, nullable=False)
     name = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(64), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
@@ -51,13 +51,13 @@ class User(db.Model)
         return True
     def generate_auth_token(self, expiration=86400):
         s = Serializer(current_app.config["SECRET_KEY"], expiration)
-        return s.dumps({"token": self.user_id})
+        return s.dumps({"token": self.id})
     #Serialize class
     @property
     def serialize(self):
         """Return object data in serializeable format"""
         return {
-            "user_id": self.user_id,
+            "id": self.id,
             "name": self.name,
             "password_hash": self.password_hash,
             "email": self.email,


### PR DESCRIPTION
# Summary
Closes #34
This issue contains changes to the [/backend/app/models.py](https://github.com/hack4impact-mcgill/mu-crm-tool/blob/main/backend/app/models.py). The User class is added, with the following columns: user_id, name, email, password_hash, and role. The class also has relationships with Note and Donation classes (backref="user"). Additionally, the class contains password properties, serialize and serialize_list functions.
	