### PR TITLE
registered project blueprint and created update project route and its unit tests

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -45,4 +45,8 @@ def create_app(config_name):
 
     app.register_blueprint(mu_user_blueprint, url_prefix="/mu_user")
 
+    from .project import project as project_blueprint
+
+    app.register_blueprint(project_blueprint, url_prefix="/project")
+
     return app

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,7 +16,7 @@ class Donation(db.Model):
     donation_source = db.Column(db.String(128), nullable=False)
     event = db.Column(db.String(128))
     num_tickets = db.Column(db.Integer)
-    added_by = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    added_by = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), nullable=True)
 
     @property
     def serialize(self):
@@ -57,14 +57,24 @@ contacts = db.Table(
     db.Column(
         "project_id",
         UUID(as_uuid=True),
-        db.ForeignKey("project.id"),
+        db.ForeignKey("projects.id"),
         primary_key=True,
         default=uuid.uuid4,
     ),
 )
+
+# Contact Model (filler to get tests to work, await model definition issue to be resolved)
+class Contact(db.Model):
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    contacttype_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("contacttypes.id"), nullable=False
+    )
+
+    def __repr__(self):
+        return "<Contact %r>" % self.id
+
+
 # Project Model
-
-
 class Project(db.Model):
     __tablename__ = "projects"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/project/routes.py
+++ b/backend/app/project/routes.py
@@ -1,0 +1,59 @@
+import uuid
+from flask import jsonify, request, abort
+from app import db
+from app.models import Project
+from . import project
+
+# update a project by id
+@project.route("/<uuid:id>/update", methods=["PUT"])
+def update_project(id):
+    data = request.get_json(force=True)
+    address = data.get("address")
+    city = data.get("city")
+    province = data.get("province")
+    postal_code = data.get("postal_code")
+    neighbourhood = data.get("neighbourhood")
+    year = data.get("year")
+    name = data.get("name")
+    # should we change the name of the attribute to project_type instead
+    type = data.get("type")
+    # subject to change as relationship between photos has not been defined
+    #    try:
+    #        photo = request.files["photo"]
+    #    except KeyError:
+    #        photo = None
+
+    project = Project.query.filter_by(id=id).first()
+    if project is None:
+        abort(404, "No project with specified ID")
+
+    if address is not None:
+        project.address = address
+
+    if city is not None:
+        project.city = city
+
+    if province is not None:
+        project.province = province
+
+    if postal_code is not None:
+        project.postal_code = postal_code
+
+    if neighbourhood is not None:
+        project.neighbourhood = neighbourhood
+
+    if year is not None:
+        project.year = year
+
+    if name is not None:
+        project.name = name
+
+    if type is not None:
+        project.type = type
+
+    if not data:
+        abort(400, "No fields to update")
+
+    db.session.add(project)
+    db.session.commit()
+    return jsonify(project.serialize)

--- a/backend/config.py
+++ b/backend/config.py
@@ -6,7 +6,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     APP_NAME = "MU CRM"
     SECRET_KEY = os.environ.get("SECRET_KEY") or "hard to guess string"
-    # SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     @staticmethod
     def init_app(app):

--- a/backend/tests/test_basics.py
+++ b/backend/tests/test_basics.py
@@ -1,6 +1,6 @@
 import unittest
 from flask import current_app
-from app import create_app
+from app import create_app, db
 
 
 class BasicsTestCase(unittest.TestCase):

--- a/backend/tests/test_project.py
+++ b/backend/tests/test_project.py
@@ -1,0 +1,73 @@
+import json
+import unittest
+import uuid
+from flask import current_app
+from app import create_app, db
+from app.models import Project
+
+
+class ProjectTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app("testing")
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_project_routes(self):
+        p_id = uuid.uuid4()
+        p = Project(
+            id=p_id,
+            address="dummy address",
+            city="dummy city",
+            province="dummy province",
+            postal_code="dummy postal_code",
+            neighbourhood="dummy neighbourhood",
+            year=2020,
+            name="dummy name",
+            type="dummy type",
+            contacts=[],
+        )
+        db.session.add(p)
+        db.session.commit()
+
+        # update a project with empty argumets
+        response = self.client.put(
+            "/project/{}/update".format(p_id),
+            content_type="application/json",
+            data=json.dumps({}),
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # update a project with valid arguments
+        update_obj = {
+            "address": "new dummy address",
+            "city": "new dummy city",
+            "province": "new dummy province",
+            "postal_code": "new dummy postal_code",
+            "neighbourhood": "new dummy neighbourhood",
+            "year": 2021,
+            "name": "new dummy name",
+            "type": "new dummy type",
+        }
+        response = self.client.put(
+            "/project/{}/update".format(p_id),
+            content_type="application/json",
+            data=json.dumps(update_obj),
+        )
+        self.assertEqual(response.status_code, 200)
+        json_response = json.loads(response.get_data(as_text=True))
+        self.assertDictContainsSubset(update_obj, json_response)
+
+        # update a project that does not exist
+        response = self.client.put(
+            "/project/{}/update".format(uuid.uuid4()),
+            content_type="application/json",
+            data=json.dumps(update_obj),
+        )
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
# Summary

I've registered the 'project' blueprint, created a route to update a project based on the specified uuid, and its unit tests.
The defined function is subject to change, as it is dependent on how the 'Photo' and 'Project' models are defined and how photos of a project should be updated.

# Details
- As the discussion for this issue mentioned, we are treating zero updates to a project as an error (i.e. if we are directed to this route without any changes proposed for the specified project, we will return an error)
- We have not discussed the way of updating the photos. As a 'Project' has many photos, would we allow a user to add new photos to the ones currently stored in the servers, or would we allow users to wipe the currently stored photos in the server and simply add the new ones. I'm leaning towards the first option, would love to hear suggestions.

## Test Plan
Unit tests
- test updating a project with empty arguments
- test updating a project with valid arguments
- test updating a project that does not exist with invalid uuid

## Related Issues

- Intended to resolve #10 
