### PR TITLE
invalid travis pass fix

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -28,7 +28,12 @@ def test():
     import unittest
 
     tests = unittest.TestLoader().discover("tests")
-    unittest.TextTestRunner(verbosity=2).run(tests)
+    result = unittest.TextTestRunner(verbosity=2).run(tests)
+
+    if result.wasSuccessful():
+        exit(0)
+    else:
+        exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

On some occasions (e.g. travis build #149), when tests fail or error out, the exit code is still 0. This is considered a pass to travis as ci systems determine pass/fail based on the exit code.
	
## Test Plan

- tried failing a test and ensured exit code was 1 with `echo $?`

## Related Issues

Which issues does this PR resolve/work on?
Closes #110 
