### PR TITLE
get donation by donor email

### DIFF
--- a/backend/app/donation/routes.py
+++ b/backend/app/donation/routes.py
@@ -1,0 +1,24 @@
+from flask import request, abort, jsonify
+from app.models import Donation
+from . import donation
+
+
+@donation.route("", methods=["GET"])
+def get_donation_amounts_by_email():
+    donations = Donation.query.all()
+
+    email = request.args.get("email")
+    if email is not None:
+        if email == "":
+            abort(404, "Invalid email address")
+
+        filtered_donation = list(
+            filter(lambda donations: (donations.email == email), donations)
+        )
+
+        # if no email is found in the database
+        if not filtered_donation:
+            abort(404, "Invalid email address")
+
+        total_amount = sum([donation.amount for donation in filtered_donation])
+        return jsonify(total_amount=total_amount)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -11,7 +11,7 @@ class Donation(db.Model):
     __tablename__ = "donations"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(64), nullable=False)
-    email = db.Column(db.String(64), unique=True, nullable=False)
+    email = db.Column(db.String(64), nullable=False)
     date = db.Column(db.DateTime(), default=datetime.datetime.utcnow)
     donation_source = db.Column(db.String(128), nullable=False)
     event = db.Column(db.String(128))

--- a/backend/tests/test_donation.py
+++ b/backend/tests/test_donation.py
@@ -45,3 +45,42 @@ class DonationTestCase(unittest.TestCase):
         db.session.add(failing_case)
         # test passes when the commit() fails due to amount field missing
         self.assertRaises(IntegrityError, db.session.commit)
+
+    def test_get_amount(self):
+        email_address = "dummy@gamil.com"
+        d1 = Donation(
+            name="dummy",
+            email=email_address,
+            date=datetime.datetime.now(),
+            donation_source="dummy",
+            event="dummy",
+            num_tickets=2,
+            amount=200,
+        )
+        d2 = Donation(
+            name="dummy2",
+            email=email_address,
+            date=datetime.datetime.now(),
+            donation_source="dummy2",
+            event="dummy2",
+            num_tickets=2,
+            amount=300,
+        )
+
+        db.session.add_all([d1, d2])
+        db.session.commit()
+
+        # testing passing case
+        response = self.client.get("/donation?email={}".format(email_address))
+        self.assertEqual(response.status_code, 200)
+        json_response = response.get_json()
+        self.assertEqual(json_response["total_amount"], 500)
+
+        # testing with missing param
+        response2 = self.client.get("/donation?email=")
+        self.assertEqual(response2.status_code, 404)
+
+        # testing with email that doesn't exist in the database
+        bad_email = "bad_email@gmail.com"
+        response3 = self.client.get("/donation?email={}".format(bad_email))
+        self.assertEqual(response3.status_code, 404)


### PR DESCRIPTION
# Summary

1. added GET endpoint to get total amount donated identified by donor email
2. Tested
3. Changed donation endpoint because the email field `email = db.Column(db.String(64), nullable=False)` was unique, which means one donation can only be linked to one single email, this didn't make sense to me and defeats the purpose of get the sum amount donated identified by a particular email **_( This step also requires a new migration, to be addressed in future PRs if confirmed )_**
	
## Test Plan

Unit tested - Passed all tests

1. Made sure correct amounts were returned
2. Made sure process aborted when incorrect email was passed in **_(subjected to change, could just return 0 instead)_**
3. Made sure process aborted when empty email was passed in

![Screen Shot 2021-02-13 at 6 25 36 PM](https://user-images.githubusercontent.com/66083521/107864297-eedadc80-6e28-11eb-916d-ec29b67d4fed.png)


## Related Issues

Which issues does this PR resolve/work on?
Closes #105 
Changes to #49 
